### PR TITLE
Fix: random game/movie status does not change on each interval update

### DIFF
--- a/canary/events/ready.js
+++ b/canary/events/ready.js
@@ -20,35 +20,35 @@ module.exports = {
         // Watching
         const moviesJsonPath = path.resolve(__dirname, './../database/movies/names.json');
         const moviesData = require(moviesJsonPath);
-        const randomMovie = Math.floor(Math.random() * moviesData.length);
         // Games
         const gamesJsonPath = path.resolve(__dirname, './../database/games/names.json');
         const gamesData = require(gamesJsonPath);
-        const randomGame = Math.floor(Math.random() * gamesData.length);
         // Status
-        const status = [
-            // Custom
-            { activities: [{ name: 'I respond to DMs', type: ActivityType.Custom }], status: 'online' },
-            { activities: [{ name: '/help', type: ActivityType.Custom }], status: 'online' },
-            {
-                activities: [{
-                    // name is exposed through the API but not shown in the client for ActivityType.Custom
-                    name: 'custom',
-                    type: ActivityType.Custom,
-                    state: '🐥',
-                }],
-                status: 'online',
-            },
-            // Listening
-            { activities: [{ name: 'me', type: ActivityType.Listening }], status: 'idle' },
-            // Watching
-            { activities: [{ name: moviesData[randomMovie], type: ActivityType.Watching }], status: 'dnd' },
-            // Games
-            { activities: [{ name: gamesData[randomGame], type: ActivityType.Playing }], status: 'idle' },
-            { activities: [{ name: gamesData[randomGame], type: ActivityType.Competing }], status: 'dnd' },
-            { activities: [{ name: gamesData[randomGame], type: ActivityType.Streaming, url: 'https://www.twitch.tv/directory' }] },
-        ];
         function updateStatus() {
+            const randomMovie = Math.floor(Math.random() * moviesData.length);
+            const randomGame = Math.floor(Math.random() * gamesData.length);
+            const status = [
+                // Custom
+                { activities: [{ name: 'I respond to DMs', type: ActivityType.Custom }], status: 'online' },
+                { activities: [{ name: '/help', type: ActivityType.Custom }], status: 'online' },
+                {
+                    activities: [{
+                        // name is exposed through the API but not shown in the client for ActivityType.Custom
+                        name: 'custom',
+                        type: ActivityType.Custom,
+                        state: '🐥',
+                    }],
+                    status: 'online',
+                },
+                // Listening
+                { activities: [{ name: 'me', type: ActivityType.Listening }], status: 'idle' },
+                // Watching
+                { activities: [{ name: moviesData[randomMovie], type: ActivityType.Watching }], status: 'dnd' },
+                // Games
+                { activities: [{ name: gamesData[randomGame], type: ActivityType.Playing }], status: 'idle' },
+                { activities: [{ name: gamesData[randomGame], type: ActivityType.Competing }], status: 'dnd' },
+                { activities: [{ name: gamesData[randomGame], type: ActivityType.Streaming, url: 'https://www.twitch.tv/directory' }] },
+            ];
             const random = Math.floor(Math.random() * status.length);
             client.user.setPresence(status[random]);
         }

--- a/docs/releases/changelog.md
+++ b/docs/releases/changelog.md
@@ -8,11 +8,11 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Added
 
-- ...
+- Dashboard support for the canary version.
 
 ### Changed
 
-- ...
+- Moved `randomMovie`, `randomGame`, and `status` array inside `updateStatus()` so new random values are computed on every call.
 
 ### Deprecated
 
@@ -24,7 +24,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 
 ### Fixed
 
-- ...
+- Random game and movie titles not rotating on each status update interval.
 
 ### Security
 


### PR DESCRIPTION
## Summary

Fix bot presence not rotating random game and movie titles on each status update interval.

## Details

`randomMovie` and `randomGame` were computed once when the `ClientReady` event fired, outside of `updateStatus()`. This meant every call to `updateStatus()` reused the same indices, always displaying the same game and movie regardless of how many times the interval triggered.

The fix moves `randomMovie`, `randomGame`, and the `status` array inside `updateStatus()` so new random values are computed on every call. `moviesData` and `gamesData` remain outside since they only need to be loaded once.

## References

[discord.js.org](https://discord.js.org/)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #5 
