### PR TITLE
Feature: add MessageContent privileged intent support

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -8,7 +8,7 @@ const client = new Client({
     intents: [
         GatewayIntentBits.Guilds,
         GatewayIntentBits.GuildMessages,
-        // GatewayIntentBits.MessageContent,
+        GatewayIntentBits.MessageContent,
     ],
 });
 


### PR DESCRIPTION
## Summary

Add `GatewayIntentBits.MessageContent` privileged intent to enable the bot to read and respond to messages via the `messageCreate` event.

## Details

Without `MessageContent`, Discord's API strips the content of every message before delivering it to the bot, causing `message.content` to always be an empty string. Adding this intent to the client in `src/index.js` brings the stable version to parity with the canary version, where this intent was already in place.

Note that this intent must also be enabled manually in the Discord Developer Portal under **Bot → Privileged Gateway Intents → Message Content Intent**, otherwise the bot will disconnect with a `Used disallowed intents` error.

## References

[discord.js Guide](https://discordjs.guide/legacy/popular-topics/intents)

## Checks

- [x] Tested changes
- [x] Stakeholder approval

## Issues

Closes #7 
